### PR TITLE
feat(m4): Driver Matching & Ride Lifecycle

### DIFF
--- a/apps/api-gateway/src/routes/ride.routes.ts
+++ b/apps/api-gateway/src/routes/ride.routes.ts
@@ -1,25 +1,28 @@
 import { Router } from 'express';
 import { validate } from '../middleware/validate.js';
-import { rideSchema } from 'common';
+import { rideSchema, otpVerifySchema, rideCancelSchema } from 'common';
 import { authenticate, authorize } from '../middleware/auth.js';
-import { cancelRide, createRide } from '../services/ride.service.js';
+import {
+  createRide,
+  cancelRide,
+  acceptRide,
+  rejectRide,
+  verifyOtp,
+  driverCancelRide,
+} from '../services/ride.service.js';
 import { getNearbyAvailableRides } from '../services/driver.service.js';
 
 const rideRouter: Router = Router();
 
+// ─── Rider endpoints ─────────────────────────────────────────────────────
+
 rideRouter.post('/create', authenticate, validate(rideSchema), async (req, res) => {
   try {
     if (!req.user) {
-      return res.status(401).json({
-        success: false,
-        message: 'Unauthorized',
-      });
+      return res.status(401).json({ success: false, message: 'Unauthorized' });
     }
-
     const ride = await createRide(req.body, req.user.userId);
-    if (!ride.success) {
-      return res.status(400).json(ride);
-    }
+    if (!ride.success) return res.status(400).json(ride);
     return res.status(201).json(ride);
   } catch (error) {
     return res.status(500).json({
@@ -29,19 +32,14 @@ rideRouter.post('/create', authenticate, validate(rideSchema), async (req, res) 
   }
 });
 
-rideRouter.patch('/cancel', authenticate, async (req, res) => {
+rideRouter.patch('/cancel', authenticate, validate(rideCancelSchema), async (req, res) => {
   try {
     if (!req.user) {
-      return res.status(401).json({
-        success: false,
-        message: 'Unauthorized',
-      });
+      return res.status(401).json({ success: false, message: 'Unauthorized' });
     }
-
-    const ride = await cancelRide(req.user.userId);
-    if (!ride.success) {
-      return res.status(400).json(ride);
-    }
+    const { tripId } = req.body;
+    const ride = await cancelRide(req.user.userId, tripId);
+    if (!ride.success) return res.status(400).json(ride);
     return res.status(200).json(ride);
   } catch (error) {
     return res.status(500).json({
@@ -51,15 +49,82 @@ rideRouter.patch('/cancel', authenticate, async (req, res) => {
   }
 });
 
+// ─── Driver endpoints ────────────────────────────────────────────────────
+
 rideRouter.get('/available', authenticate, authorize('driver'), async (req, res) => {
   try {
     if (!req.user) {
-      return res.status(401).json({
-        success: false,
-        message: 'Unauthorized',
-      });
+      return res.status(401).json({ success: false, message: 'Unauthorized' });
     }
     const result = await getNearbyAvailableRides(req.user.userId);
+    return res.status(result.success ? 200 : 400).json(result);
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: error instanceof Error ? error.message : 'Internal server error',
+    });
+  }
+});
+
+rideRouter.post('/:tripId/accept', authenticate, authorize('driver'), async (req, res) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ success: false, message: 'Unauthorized' });
+    }
+    const { offerId } = req.body;
+    if (!offerId) {
+      return res.status(400).json({ success: false, message: 'offerId is required' });
+    }
+    const result = await acceptRide(req.user.userId, req.params.tripId, offerId);
+    return res.status(result.success ? 200 : 400).json(result);
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: error instanceof Error ? error.message : 'Internal server error',
+    });
+  }
+});
+
+rideRouter.post('/:tripId/reject', authenticate, authorize('driver'), async (req, res) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ success: false, message: 'Unauthorized' });
+    }
+    const { offerId } = req.body;
+    if (!offerId) {
+      return res.status(400).json({ success: false, message: 'offerId is required' });
+    }
+    const result = await rejectRide(req.user.userId, req.params.tripId, offerId);
+    return res.status(result.success ? 200 : 400).json(result);
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: error instanceof Error ? error.message : 'Internal server error',
+    });
+  }
+});
+
+rideRouter.post('/:tripId/verify-otp', authenticate, authorize('driver'), validate(otpVerifySchema), async (req, res) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ success: false, message: 'Unauthorized' });
+    }
+    const result = await verifyOtp(req.user.userId, req.params.tripId, req.body.otp);
+    return res.status(result.success ? 200 : 400).json(result);
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: error instanceof Error ? error.message : 'Internal server error',
+    });
+  }
+});
+
+rideRouter.post('/:tripId/driver-cancel', authenticate, authorize('driver'), async (req, res) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ success: false, message: 'Unauthorized' });
+    }
+    const result = await driverCancelRide(req.user.userId, req.params.tripId);
     return res.status(result.success ? 200 : 400).json(result);
   } catch (error) {
     return res.status(500).json({

--- a/apps/api-gateway/src/services/__tests__/ride.service.test.ts
+++ b/apps/api-gateway/src/services/__tests__/ride.service.test.ts
@@ -4,14 +4,19 @@ const prismaMock = vi.hoisted(() => ({
   user: { findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
   driver: { findUnique: vi.fn(), create: vi.fn(), update: vi.fn() },
   rider: { findUnique: vi.fn(), create: vi.fn() },
-  trip: { findFirst: vi.fn(), update: vi.fn() },
+  trip: { findFirst: vi.fn(), findUnique: vi.fn(), update: vi.fn() },
+  rideOffer: { findUnique: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
   $transaction: vi.fn(),
   $queryRaw: vi.fn(),
 }));
 
 const queueAddMock = vi.hoisted(() => vi.fn().mockResolvedValue({ id: 'job-1' }));
+const redisSetMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../utils/db.js', () => ({ default: prismaMock }));
+vi.mock('../../utils/redis.js', () => ({
+  default: { set: redisSetMock, get: vi.fn(), del: vi.fn() },
+}));
 vi.mock('../../logger.js', () => ({ default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() } }));
 vi.mock('bullmq', () => {
   const QueueMock = vi.fn(function (this: Record<string, unknown>) {
@@ -21,9 +26,10 @@ vi.mock('bullmq', () => {
   return { Queue: QueueMock };
 });
 
-import { createRide, cancelRide } from '../ride.service.js';
+import { createRide, cancelRide, acceptRide, rejectRide, verifyOtp } from '../ride.service.js';
 
 const mockRider = { id: 'rider-1', userId: 'user-1' };
+const mockDriver = { id: 'driver-1', userId: 'user-driver-1' };
 
 const mockRideRow = {
   id: 'trip-1',
@@ -68,7 +74,6 @@ describe('ride.service', () => {
       expect(result.data?.id).toBe('trip-1');
       expect(result.data?.status).toBe('REQUESTED');
       expect(prismaMock.$queryRaw).toHaveBeenCalledOnce();
-      // M2: verify ride job is published to BullMQ queue
       expect(queueAddMock).toHaveBeenCalledWith(
         'new-ride',
         expect.objectContaining({
@@ -89,25 +94,142 @@ describe('ride.service', () => {
       prismaMock.rider.findUnique.mockResolvedValue(mockRider);
       prismaMock.trip.findFirst.mockResolvedValue(null);
 
-      const result = await cancelRide('user-1');
+      const result = await cancelRide('user-1', 'trip-1');
 
       expect(result.success).toBe(false);
       expect(result.message).toMatch(/no active ride/i);
-      expect(prismaMock.trip.update).not.toHaveBeenCalled();
     });
 
-    it('cancels the ride and returns success', async () => {
+    it('publishes cancel job to lifecycle queue', async () => {
       prismaMock.rider.findUnique.mockResolvedValue(mockRider);
       prismaMock.trip.findFirst.mockResolvedValue({ id: 'trip-1', riderId: 'rider-1', status: 'REQUESTED' });
-      prismaMock.trip.update.mockResolvedValue({ id: 'trip-1', status: 'CANCELLED' });
 
-      const result = await cancelRide('user-1');
+      const result = await cancelRide('user-1', 'trip-1');
 
       expect(result.success).toBe(true);
-      expect(prismaMock.trip.update).toHaveBeenCalledWith({
-        where: { id: 'trip-1' },
-        data: { status: 'CANCELLED' },
+      expect(result.message).toMatch(/cancellation submitted/i);
+      expect(queueAddMock).toHaveBeenCalledWith(
+        'lifecycle-cancel',
+        expect.objectContaining({
+          action: 'CANCEL',
+          tripId: 'trip-1',
+          reason: 'rider cancelled',
+        }),
+        expect.objectContaining({ jobId: 'cancel:trip-1' })
+      );
+    });
+  });
+
+  // ── acceptRide ────────────────────────────────────────────────
+
+  describe('acceptRide', () => {
+    it('returns error if driver not found', async () => {
+      prismaMock.driver.findUnique.mockResolvedValue(null);
+      const result = await acceptRide('user-driver-1', 'trip-1', 'offer-1');
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/driver not found/i);
+    });
+
+    it('returns error if offer is not PENDING', async () => {
+      prismaMock.driver.findUnique.mockResolvedValue(mockDriver);
+      prismaMock.rideOffer.findUnique.mockResolvedValue({ id: 'offer-1', driverId: 'driver-1', status: 'EXPIRED' });
+      const result = await acceptRide('user-driver-1', 'trip-1', 'offer-1');
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/no longer available/i);
+    });
+
+    it('publishes accept job after acquiring SETNX lock', async () => {
+      prismaMock.driver.findUnique.mockResolvedValue(mockDriver);
+      prismaMock.rideOffer.findUnique.mockResolvedValue({ id: 'offer-1', driverId: 'driver-1', status: 'PENDING' });
+      redisSetMock.mockResolvedValue('OK'); // SETNX success
+
+      const result = await acceptRide('user-driver-1', 'trip-1', 'offer-1');
+
+      expect(result.success).toBe(true);
+      expect(result.message).toMatch(/accepted/i);
+      expect(redisSetMock).toHaveBeenCalledWith('ride:lock:trip-1', 'driver-1', 'EX', 300, 'NX');
+      expect(queueAddMock).toHaveBeenCalledWith(
+        'lifecycle-accept',
+        expect.objectContaining({
+          action: 'ACCEPT',
+          tripId: 'trip-1',
+          driverId: 'driver-1',
+          offerId: 'offer-1',
+        }),
+        expect.objectContaining({ jobId: 'accept:trip-1' })
+      );
+    });
+
+    it('returns error if SETNX lock fails (race condition)', async () => {
+      prismaMock.driver.findUnique.mockResolvedValue(mockDriver);
+      prismaMock.rideOffer.findUnique.mockResolvedValue({ id: 'offer-1', driverId: 'driver-1', status: 'PENDING' });
+      redisSetMock.mockResolvedValue(null); // SETNX failed
+
+      const result = await acceptRide('user-driver-1', 'trip-1', 'offer-1');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/already been accepted/i);
+    });
+  });
+
+  // ── rejectRide ────────────────────────────────────────────────
+
+  describe('rejectRide', () => {
+    it('marks offer as REJECTED and triggers cascade', async () => {
+      prismaMock.driver.findUnique.mockResolvedValue(mockDriver);
+      prismaMock.rideOffer.findUnique.mockResolvedValue({ id: 'offer-1', driverId: 'driver-1', status: 'PENDING' });
+      prismaMock.rideOffer.update.mockResolvedValue({ id: 'offer-1', status: 'REJECTED' });
+      prismaMock.trip.findUnique.mockResolvedValue({ id: 'trip-1', riderId: 'rider-1' });
+      prismaMock.$queryRaw.mockResolvedValue([{ lng: 77.5946, lat: 12.9716 }]);
+
+      const result = await rejectRide('user-driver-1', 'trip-1', 'offer-1');
+
+      expect(result.success).toBe(true);
+      expect(prismaMock.rideOffer.update).toHaveBeenCalledWith({
+        where: { id: 'offer-1' },
+        data: { status: 'REJECTED' },
       });
+      // Should trigger cascade matching job
+      expect(queueAddMock).toHaveBeenCalledWith(
+        'cascade-reject',
+        expect.objectContaining({
+          tripId: 'trip-1',
+          skippedDriverIds: ['user-driver-1'],
+        }),
+        expect.anything()
+      );
+    });
+  });
+
+  // ── verifyOtp ─────────────────────────────────────────────────
+
+  describe('verifyOtp', () => {
+    it('returns error if driver not assigned to trip', async () => {
+      prismaMock.driver.findUnique.mockResolvedValue({ id: 'driver-2', userId: 'user-driver-2' });
+      prismaMock.trip.findUnique.mockResolvedValue({ id: 'trip-1', driverId: 'driver-1', status: 'ACCEPTED' });
+
+      const result = await verifyOtp('user-driver-2', 'trip-1', '1234');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/not assigned/i);
+    });
+
+    it('publishes VERIFY_OTP job when driver is assigned', async () => {
+      prismaMock.driver.findUnique.mockResolvedValue(mockDriver);
+      prismaMock.trip.findUnique.mockResolvedValue({ id: 'trip-1', driverId: 'driver-1', status: 'ACCEPTED' });
+
+      const result = await verifyOtp('user-driver-1', 'trip-1', '1234');
+
+      expect(result.success).toBe(true);
+      expect(queueAddMock).toHaveBeenCalledWith(
+        'lifecycle-verify-otp',
+        expect.objectContaining({
+          action: 'VERIFY_OTP',
+          tripId: 'trip-1',
+          otp: '1234',
+        }),
+        expect.anything()
+      );
     });
   });
 });

--- a/apps/api-gateway/src/services/ride.service.ts
+++ b/apps/api-gateway/src/services/ride.service.ts
@@ -1,7 +1,8 @@
 import { Queue } from 'bullmq';
-import { QUEUE_NAMES } from 'common';
+import { QUEUE_NAMES, RIDE_LOCK_KEY_PREFIX } from 'common';
 import logger from '../logger.js';
 import prisma from '../utils/db.js';
+import redis from '../utils/redis.js';
 import type { RideInput } from 'common';
 
 const bullmqConnection = {
@@ -13,18 +14,27 @@ const rideRequestsQueue = new Queue(QUEUE_NAMES.RIDE_REQUESTS, {
   connection: bullmqConnection,
 });
 
-// Graceful shutdown — close BullMQ queue to prevent connection leaks
-let rideRequestsQueueShutdownRegistered = false;
+const rideLifecycleQueue = new Queue(QUEUE_NAMES.RIDE_LIFECYCLE, {
+  connection: bullmqConnection,
+});
 
-const registerRideRequestsQueueShutdown = (queue: Queue): void => {
-  if (rideRequestsQueueShutdownRegistered) return;
-  rideRequestsQueueShutdownRegistered = true;
+const rideMatchingQueue = new Queue(QUEUE_NAMES.RIDE_MATCHING, {
+  connection: bullmqConnection,
+});
 
+// Graceful shutdown — close BullMQ queues to prevent connection leaks
+let shutdownRegistered = false;
+
+const registerQueuesShutdown = (): void => {
+  if (shutdownRegistered) return;
+  shutdownRegistered = true;
+
+  const queues = [rideRequestsQueue, rideLifecycleQueue, rideMatchingQueue];
   const shutdown = async (): Promise<void> => {
     try {
-      await queue.close();
+      await Promise.all(queues.map((q) => q.close()));
     } catch (error) {
-      logger.error(error, 'Error closing rideRequestsQueue during shutdown');
+      logger.error(error, 'Error closing BullMQ queues during shutdown');
     }
   };
 
@@ -34,35 +44,26 @@ const registerRideRequestsQueueShutdown = (queue: Queue): void => {
   });
 };
 
-registerRideRequestsQueueShutdown(rideRequestsQueue);
+registerQueuesShutdown();
 
 export interface RideResponse {
   success: boolean;
   message: string;
-  data?: {
-    id: string;
-    riderId: string;
-    pickupLocation: string;
-    dropoffLocation: string;
-    status: string;
-    createdAt: Date;
-  };
+  data?: Record<string, unknown>;
 }
+
+// ─── CREATE RIDE ──────────────────────────────────────────────────────────
 
 export const createRide = async (input: RideInput, riderId: string): Promise<RideResponse> => {
   try {
     const { pickupLocation, dropoffLocation } = input;
 
-    // find the rider first then create ride
     const rider = await prisma.rider.findUnique({
       where: { userId: riderId },
     });
 
     if (!rider) {
-      return {
-        success: false,
-        message: 'Rider not found',
-      };
+      return { success: false, message: 'Rider not found' };
     }
 
     const result = await prisma.$queryRaw<
@@ -93,7 +94,6 @@ export const createRide = async (input: RideInput, riderId: string): Promise<Rid
 
     const newRide = result[0];
 
-    // Publish job to ride-requests queue for async processing
     await rideRequestsQueue.add(
       'new-ride',
       {
@@ -112,7 +112,7 @@ export const createRide = async (input: RideInput, riderId: string): Promise<Rid
     return {
       success: true,
       message: 'Ride created successfully',
-      data: newRide,
+      data: newRide as unknown as Record<string, unknown>,
     };
   } catch (error) {
     logger.error(error, 'Error creating ride');
@@ -120,41 +120,226 @@ export const createRide = async (input: RideInput, riderId: string): Promise<Rid
   }
 };
 
-export const cancelRide = async (userId: string): Promise<RideResponse> => {
+// ─── ACCEPT RIDE ──────────────────────────────────────────────────────────
+
+export const acceptRide = async (
+  userId: string,
+  tripId: string,
+  offerId: string,
+): Promise<RideResponse> => {
   try {
-    const riderid = await prisma.rider.findUnique({
-      where: {
-        userId: userId,
-      },
-    });
+    // 1. Find driver record
+    const driver = await prisma.driver.findUnique({ where: { userId } });
+    if (!driver) return { success: false, message: 'Driver not found' };
 
-    const ride = await prisma.trip.findFirst({
-      where: {
-        riderId: riderid?.id,
-        status: 'REQUESTED',
-      },
-    });
+    // 2. Validate offer exists and belongs to this driver
+    const offer = await prisma.rideOffer.findUnique({ where: { id: offerId } });
+    if (!offer) return { success: false, message: 'Offer not found' };
+    if (offer.driverId !== driver.id) return { success: false, message: 'Offer not assigned to you' };
+    if (offer.status !== 'PENDING') return { success: false, message: 'Offer is no longer available' };
 
-    if (!ride) {
-      return {
-        success: false,
-        message: 'No active ride found to cancel',
-      };
+    // 3. Race condition protection: SETNX distributed lock
+    const lockKey = `${RIDE_LOCK_KEY_PREFIX}${tripId}`;
+    const lockAcquired = await redis.set(lockKey, driver.id, 'EX', 300, 'NX');
+
+    if (!lockAcquired) {
+      return { success: false, message: 'Ride has already been accepted by another driver' };
     }
 
-    await prisma.trip.update({
-      where: {
-        id: ride.id,
+    // 4. Publish ride-lifecycle ACCEPT job
+    await rideLifecycleQueue.add(
+      'lifecycle-accept',
+      {
+        action: 'ACCEPT' as const,
+        tripId,
+        driverId: driver.id,
+        offerId,
       },
-      data: {
-        status: 'CANCELLED',
-      },
+      { jobId: `accept:${tripId}` },
+    );
+
+    logger.info({ tripId, driverId: driver.id, offerId }, 'Ride accept job published');
+
+    return { success: true, message: 'Ride accepted — processing' };
+  } catch (error) {
+    logger.error(error, 'Error accepting ride');
+    throw new Error('Could not accept ride. Please try again.');
+  }
+};
+
+// ─── REJECT RIDE ──────────────────────────────────────────────────────────
+
+export const rejectRide = async (
+  userId: string,
+  tripId: string,
+  offerId: string,
+): Promise<RideResponse> => {
+  try {
+    const driver = await prisma.driver.findUnique({ where: { userId } });
+    if (!driver) return { success: false, message: 'Driver not found' };
+
+    const offer = await prisma.rideOffer.findUnique({ where: { id: offerId } });
+    if (!offer) return { success: false, message: 'Offer not found' };
+    if (offer.driverId !== driver.id) return { success: false, message: 'Offer not assigned to you' };
+
+    // Mark offer as REJECTED
+    await prisma.rideOffer.update({
+      where: { id: offerId },
+      data: { status: 'REJECTED' },
     });
 
-    return {
-      success: true,
-      message: 'Ride cancelled successfully',
-    };
+    // Get the trip to fetch coords for cascade
+    const trip = await prisma.trip.findUnique({ where: { id: tripId } });
+    if (!trip) return { success: false, message: 'Trip not found' };
+
+    // Parse pickup/dropoff coordinates from geometry
+    const pickupCoords = await prisma.$queryRaw<{ lng: number; lat: number }[]>`
+      SELECT ST_X("pickupLocation") as lng, ST_Y("pickupLocation") as lat
+      FROM "Trip" WHERE id = ${tripId}
+    `;
+    const dropoffCoords = await prisma.$queryRaw<{ lng: number; lat: number }[]>`
+      SELECT ST_X("dropoffLocation") as lng, ST_Y("dropoffLocation") as lat
+      FROM "Trip" WHERE id = ${tripId}
+    `;
+
+    // Trigger immediate cascade to next driver (no delay)
+    await rideMatchingQueue.add(
+      'cascade-reject',
+      {
+        tripId,
+        riderId: trip.riderId,
+        pickupLng: pickupCoords[0]?.lng ?? 0,
+        pickupLat: pickupCoords[0]?.lat ?? 0,
+        dropoffLng: dropoffCoords[0]?.lng ?? 0,
+        dropoffLat: dropoffCoords[0]?.lat ?? 0,
+        attempt: 1,
+        skippedDriverIds: [userId],
+      },
+      { jobId: `reject-cascade:${tripId}:${offerId}` },
+    );
+
+    logger.info({ tripId, offerId, driverId: driver.id }, 'Offer rejected — cascading');
+
+    return { success: true, message: 'Ride rejected' };
+  } catch (error) {
+    logger.error(error, 'Error rejecting ride');
+    throw new Error('Could not reject ride. Please try again.');
+  }
+};
+
+// ─── VERIFY OTP ───────────────────────────────────────────────────────────
+
+export const verifyOtp = async (
+  userId: string,
+  tripId: string,
+  otp: string,
+): Promise<RideResponse> => {
+  try {
+    const driver = await prisma.driver.findUnique({ where: { userId } });
+    if (!driver) return { success: false, message: 'Driver not found' };
+
+    // Validate driver is assigned to this trip
+    const trip = await prisma.trip.findUnique({ where: { id: tripId } });
+    if (!trip) return { success: false, message: 'Trip not found' };
+    if (trip.driverId !== driver.id) return { success: false, message: 'You are not assigned to this ride' };
+    if (trip.status !== 'ACCEPTED') return { success: false, message: 'Ride is not in ACCEPTED state' };
+
+    // Publish ride-lifecycle VERIFY_OTP job
+    await rideLifecycleQueue.add(
+      'lifecycle-verify-otp',
+      {
+        action: 'VERIFY_OTP' as const,
+        tripId,
+        driverId: driver.id,
+        otp,
+      },
+      { jobId: `verify-otp:${tripId}:${Date.now()}` },
+    );
+
+    return { success: true, message: 'OTP verification submitted' };
+  } catch (error) {
+    logger.error(error, 'Error verifying OTP');
+    throw new Error('Could not verify OTP. Please try again.');
+  }
+};
+
+// ─── CANCEL RIDE (enhanced with tripId) ──────────────────────────────────
+
+export const cancelRide = async (userId: string, tripId?: string): Promise<RideResponse> => {
+  try {
+    const rider = await prisma.rider.findUnique({
+      where: { userId },
+    });
+
+    let ride;
+
+    if (tripId) {
+      // Cancel specific trip
+      ride = await prisma.trip.findFirst({
+        where: {
+          id: tripId,
+          riderId: rider?.id,
+          status: { in: ['REQUESTED', 'ACCEPTED'] },
+        },
+      });
+    } else {
+      // Legacy: cancel most recent active ride
+      ride = await prisma.trip.findFirst({
+        where: {
+          riderId: rider?.id,
+          status: { in: ['REQUESTED', 'ACCEPTED'] },
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+    }
+
+    if (!ride) {
+      return { success: false, message: 'No active ride found to cancel' };
+    }
+
+    // Publish cancel to lifecycle queue for proper cleanup
+    await rideLifecycleQueue.add(
+      'lifecycle-cancel',
+      {
+        action: 'CANCEL' as const,
+        tripId: ride.id,
+        riderId: rider?.id,
+        reason: 'rider cancelled',
+      },
+      { jobId: `cancel:${ride.id}` },
+    );
+
+    return { success: true, message: 'Ride cancellation submitted' };
+  } catch (error) {
+    logger.error(error, 'Error cancelling ride');
+    throw new Error('Could not cancel ride. Please try again.');
+  }
+};
+
+// ─── DRIVER CANCEL ───────────────────────────────────────────────────────
+
+export const driverCancelRide = async (userId: string, tripId: string): Promise<RideResponse> => {
+  try {
+    const driver = await prisma.driver.findUnique({ where: { userId } });
+    if (!driver) return { success: false, message: 'Driver not found' };
+
+    const trip = await prisma.trip.findUnique({ where: { id: tripId } });
+    if (!trip) return { success: false, message: 'Trip not found' };
+    if (trip.driverId !== driver.id) return { success: false, message: 'You are not assigned to this ride' };
+    if (trip.status !== 'ACCEPTED') return { success: false, message: 'Can only cancel an ACCEPTED ride' };
+
+    await rideLifecycleQueue.add(
+      'lifecycle-cancel',
+      {
+        action: 'CANCEL' as const,
+        tripId,
+        driverId: driver.id,
+        reason: 'driver cancelled',
+      },
+      { jobId: `driver-cancel:${tripId}` },
+    );
+
+    return { success: true, message: 'Ride cancellation submitted' };
   } catch (error) {
     logger.error(error, 'Error cancelling ride');
     throw new Error('Could not cancel ride. Please try again.');

--- a/apps/api-gateway/src/sockets/__tests__/driver-handler.test.ts
+++ b/apps/api-gateway/src/sockets/__tests__/driver-handler.test.ts
@@ -5,11 +5,17 @@ import type { Socket } from 'socket.io';
 const setDriverOnlineMock = vi.hoisted(() => vi.fn());
 const setDriverOfflineMock = vi.hoisted(() => vi.fn());
 const updateDriverLocationMock = vi.hoisted(() => vi.fn());
+const acceptRideMock = vi.hoisted(() => vi.fn());
+const rejectRideMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../services/driver.service.js', () => ({
     setDriverOnline: setDriverOnlineMock,
     setDriverOffline: setDriverOfflineMock,
     updateDriverLocation: updateDriverLocationMock,
+}));
+vi.mock('../../services/ride.service.js', () => ({
+    acceptRide: acceptRideMock,
+    rejectRide: rejectRideMock,
 }));
 vi.mock('../../logger.js', () => ({
     default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -17,7 +23,7 @@ vi.mock('../../logger.js', () => ({
 
 import { registerDriverHandlers } from '../handlers/driver.js';
 
-const makeSocket = (userId: string): Socket => {
+const makeSocket = (userId: string): Socket & { _trigger: (e: string, ...a: unknown[]) => Promise<void> } => {
     const listeners: Record<string, (...args: unknown[]) => void> = {};
     return {
         id: 'socket-driver',
@@ -27,8 +33,8 @@ const makeSocket = (userId: string): Socket => {
         on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
             listeners[event] = handler;
         }),
-        _trigger: (event: string, ...args: unknown[]) => listeners[event]?.(...args),
-    } as unknown as Socket & { _trigger: (e: string, ...a: unknown[]) => void };
+        _trigger: async (event: string, ...args: unknown[]) => { await listeners[event]?.(...args); },
+    } as unknown as Socket & { _trigger: (e: string, ...a: unknown[]) => Promise<void> };
 };
 
 describe('registerDriverHandlers', () => {
@@ -42,27 +48,53 @@ describe('registerDriverHandlers', () => {
 
     it('driver:go-online calls setDriverOnline and emits ack', async () => {
         setDriverOnlineMock.mockResolvedValue({ success: true, message: 'Driver is now online' });
-        const socket = makeSocket('user-driver-1') as Socket & { _trigger: (e: string, ...a: unknown[]) => void };
+        const socket = makeSocket('user-driver-1');
         registerDriverHandlers(socket);
-        await (socket as unknown as { _trigger: (e: string, ...a: unknown[]) => Promise<void> })._trigger('driver:go-online', { lng: 77.5, lat: 12.9 });
+        await socket._trigger('driver:go-online', { lng: 77.5, lat: 12.9 });
         expect(setDriverOnlineMock).toHaveBeenCalledWith('user-driver-1', [77.5, 12.9]);
         expect(socket.emit).toHaveBeenCalledWith('driver:go-online:ack', { success: true, message: 'Driver is now online' });
     });
 
     it('driver:go-offline calls setDriverOffline and emits ack', async () => {
         setDriverOfflineMock.mockResolvedValue({ success: true, message: 'Driver is now offline' });
-        const socket = makeSocket('user-driver-1') as Socket & { _trigger: (e: string, ...a: unknown[]) => Promise<void> };
+        const socket = makeSocket('user-driver-1');
         registerDriverHandlers(socket);
         await socket._trigger('driver:go-offline');
         expect(setDriverOfflineMock).toHaveBeenCalledWith('user-driver-1');
-        expect(socket.emit).toHaveBeenCalledWith('driver:go-offline:ack', { success: true, message: 'Driver is now offline' });
     });
 
     it('driver:location-update calls updateDriverLocation', async () => {
-        updateDriverLocationMock.mockResolvedValue({ success: true, message: 'Location updated' });
-        const socket = makeSocket('user-driver-1') as Socket & { _trigger: (e: string, ...a: unknown[]) => Promise<void> };
+        updateDriverLocationMock.mockResolvedValue(undefined);
+        const socket = makeSocket('user-driver-1');
         registerDriverHandlers(socket);
         await socket._trigger('driver:location-update', { lng: 77.6, lat: 12.8 });
         expect(updateDriverLocationMock).toHaveBeenCalledWith('user-driver-1', [77.6, 12.8]);
+    });
+
+    it('driver:accept-ride calls acceptRide and emits ack', async () => {
+        acceptRideMock.mockResolvedValue({ success: true, message: 'Ride accepted — processing' });
+        const socket = makeSocket('user-driver-1');
+        registerDriverHandlers(socket);
+        await socket._trigger('driver:accept-ride', { tripId: 'trip-1', offerId: 'offer-1' });
+        expect(acceptRideMock).toHaveBeenCalledWith('user-driver-1', 'trip-1', 'offer-1');
+        expect(socket.emit).toHaveBeenCalledWith('driver:accept-ride:ack', { success: true, message: 'Ride accepted — processing' });
+        expect(socket.join).toHaveBeenCalledWith('ride:trip-1');
+    });
+
+    it('driver:accept-ride does NOT join ride room on failure', async () => {
+        acceptRideMock.mockResolvedValue({ success: false, message: 'Already accepted' });
+        const socket = makeSocket('user-driver-1');
+        registerDriverHandlers(socket);
+        await socket._trigger('driver:accept-ride', { tripId: 'trip-1', offerId: 'offer-1' });
+        expect(socket.join).not.toHaveBeenCalledWith('ride:trip-1');
+    });
+
+    it('driver:reject-ride calls rejectRide and emits ack', async () => {
+        rejectRideMock.mockResolvedValue({ success: true, message: 'Ride rejected' });
+        const socket = makeSocket('user-driver-1');
+        registerDriverHandlers(socket);
+        await socket._trigger('driver:reject-ride', { tripId: 'trip-1', offerId: 'offer-1' });
+        expect(rejectRideMock).toHaveBeenCalledWith('user-driver-1', 'trip-1', 'offer-1');
+        expect(socket.emit).toHaveBeenCalledWith('driver:reject-ride:ack', { success: true, message: 'Ride rejected' });
     });
 });

--- a/apps/api-gateway/src/sockets/handlers/driver.ts
+++ b/apps/api-gateway/src/sockets/handlers/driver.ts
@@ -1,5 +1,6 @@
 import type { Socket } from 'socket.io';
 import { setDriverOnline, setDriverOffline, updateDriverLocation } from '../../services/driver.service.js';
+import { acceptRide, rejectRide } from '../../services/ride.service.js';
 import type { JwtPayload } from '../../utils/jwt.js';
 import logger from '../../logger.js';
 
@@ -8,9 +9,11 @@ import logger from '../../logger.js';
  * Auto-joins the driver's personal room `driver:{driverId}`.
  *
  * Events:
- *   driver:go-online       { lng, lat }   → set online in DB + Redis GEO
- *   driver:go-offline      {}             → set offline in DB + remove from Redis GEO
- *   driver:location-update { lng, lat }   → update Redis GEO position
+ *   driver:go-online       { lng, lat }                → set online in DB + Redis GEO
+ *   driver:go-offline      {}                          → set offline in DB + remove from Redis GEO
+ *   driver:location-update { lng, lat }                → update Redis GEO position
+ *   driver:accept-ride     { tripId, offerId }         → accept ride offer (SETNX lock)
+ *   driver:reject-ride     { tripId, offerId }         → reject ride offer → cascade
  */
 export const registerDriverHandlers = (socket: Socket): void => {
     const user = socket.data.user as JwtPayload;
@@ -44,6 +47,30 @@ export const registerDriverHandlers = (socket: Socket): void => {
             await updateDriverLocation(user.userId, [data.lng, data.lat]);
         } catch (err) {
             logger.error({ err, userId: user.userId }, 'Error handling driver:location-update');
+        }
+    });
+
+    socket.on('driver:accept-ride', async (data: { tripId: string; offerId: string }) => {
+        try {
+            const result = await acceptRide(user.userId, data.tripId, data.offerId);
+            socket.emit('driver:accept-ride:ack', result);
+            if (result.success) {
+                // Auto-join the ride room
+                void socket.join(`ride:${data.tripId}`);
+            }
+        } catch (err) {
+            logger.error({ err, userId: user.userId }, 'Error handling driver:accept-ride');
+            socket.emit('error', { message: 'Failed to accept ride' });
+        }
+    });
+
+    socket.on('driver:reject-ride', async (data: { tripId: string; offerId: string }) => {
+        try {
+            const result = await rejectRide(user.userId, data.tripId, data.offerId);
+            socket.emit('driver:reject-ride:ack', result);
+        } catch (err) {
+            logger.error({ err, userId: user.userId }, 'Error handling driver:reject-ride');
+            socket.emit('error', { message: 'Failed to reject ride' });
         }
     });
 };

--- a/apps/ride-worker/package.json
+++ b/apps/ride-worker/package.json
@@ -4,6 +4,9 @@
   "description": "BullMQ worker for ride lifecycle processing",
   "main": "dist/index.js",
   "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "build": "tsc -p tsconfig.json",
     "dev": "tsx watch src/index.ts",
     "start": "node ./dist/index.js"
@@ -14,9 +17,11 @@
   "type": "module",
   "devDependencies": {
     "@types/node": "^24.5.2",
+    "@vitest/coverage-v8": "^4.0.18",
     "pino-pretty": "^13.1.2",
     "tsx": "^4.20.6",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "^4.0.18"
   },
   "dependencies": {
     "@prisma/client": "^6.17.1",

--- a/apps/ride-worker/src/__tests__/state-machine.test.ts
+++ b/apps/ride-worker/src/__tests__/state-machine.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the logger before importing the module
+vi.mock('../logger.js', () => ({
+    default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { validateTransition, isValidTransition } from '../state-machine.js';
+
+describe('Ride State Machine', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    // ─── Valid transitions ─────────────────────────────────────────────────
+
+    it('allows REQUESTED → ACCEPTED', () => {
+        expect(() => validateTransition('REQUESTED', 'ACCEPTED')).not.toThrow();
+    });
+
+    it('allows REQUESTED → CANCELLED', () => {
+        expect(() => validateTransition('REQUESTED', 'CANCELLED')).not.toThrow();
+    });
+
+    it('allows ACCEPTED → STARTED', () => {
+        expect(() => validateTransition('ACCEPTED', 'STARTED')).not.toThrow();
+    });
+
+    it('allows ACCEPTED → CANCELLED', () => {
+        expect(() => validateTransition('ACCEPTED', 'CANCELLED')).not.toThrow();
+    });
+
+    it('allows STARTED → COMPLETED', () => {
+        expect(() => validateTransition('STARTED', 'COMPLETED')).not.toThrow();
+    });
+
+    // ─── Invalid transitions ───────────────────────────────────────────────
+
+    it('rejects REQUESTED → STARTED', () => {
+        expect(() => validateTransition('REQUESTED', 'STARTED')).toThrow('Invalid ride transition');
+    });
+
+    it('rejects REQUESTED → COMPLETED', () => {
+        expect(() => validateTransition('REQUESTED', 'COMPLETED')).toThrow('Invalid ride transition');
+    });
+
+    it('rejects ACCEPTED → COMPLETED (skip STARTED)', () => {
+        expect(() => validateTransition('ACCEPTED', 'COMPLETED')).toThrow('Invalid ride transition');
+    });
+
+    it('rejects STARTED → CANCELLED', () => {
+        expect(() => validateTransition('STARTED', 'CANCELLED')).toThrow('Invalid ride transition');
+    });
+
+    it('rejects COMPLETED → anything', () => {
+        expect(() => validateTransition('COMPLETED', 'CANCELLED')).toThrow('Invalid ride transition');
+        expect(() => validateTransition('COMPLETED', 'STARTED')).toThrow('Invalid ride transition');
+    });
+
+    it('rejects CANCELLED → anything', () => {
+        expect(() => validateTransition('CANCELLED', 'REQUESTED')).toThrow('Invalid ride transition');
+        expect(() => validateTransition('CANCELLED', 'ACCEPTED')).toThrow('Invalid ride transition');
+    });
+
+    // ─── isValidTransition (non-throwing) ──────────────────────────────────
+
+    it('isValidTransition returns true for valid transitions', () => {
+        expect(isValidTransition('REQUESTED', 'ACCEPTED')).toBe(true);
+        expect(isValidTransition('ACCEPTED', 'STARTED')).toBe(true);
+        expect(isValidTransition('STARTED', 'COMPLETED')).toBe(true);
+    });
+
+    it('isValidTransition returns false for invalid transitions', () => {
+        expect(isValidTransition('REQUESTED', 'STARTED')).toBe(false);
+        expect(isValidTransition('COMPLETED', 'CANCELLED')).toBe(false);
+        expect(isValidTransition('CANCELLED', 'ACCEPTED')).toBe(false);
+    });
+});

--- a/apps/ride-worker/src/matching/cascade.ts
+++ b/apps/ride-worker/src/matching/cascade.ts
@@ -1,0 +1,300 @@
+import { Queue } from 'bullmq';
+import { PrismaClient } from '@prisma/client';
+import redis from '../utils/redis.js';
+import logger from '../logger.js';
+import { QUEUE_NAMES, REDIS_CONFIG } from '../config.js';
+import {
+    MATCHING_RADIUS_KM,
+    MATCHING_EXPANDED_RADIUS_KM,
+    OFFER_TIMEOUT_SECONDS,
+    MAX_CASCADE_ATTEMPTS,
+    DRIVERS_BUSY_KEY,
+    DRIVERS_GEO_KEY,
+} from 'common';
+
+const prisma = new PrismaClient();
+
+const rideLifecycleQueue = new Queue(QUEUE_NAMES.RIDE_LIFECYCLE, {
+    connection: REDIS_CONFIG,
+});
+
+const rideMatchingQueue = new Queue(QUEUE_NAMES.RIDE_MATCHING, {
+    connection: REDIS_CONFIG,
+});
+
+export interface CascadeContext {
+    tripId: string;
+    riderId: string;
+    pickupLng: number;
+    pickupLat: number;
+    dropoffLng: number;
+    dropoffLat: number;
+    attempt: number;
+    /** Driver IDs already offered to (to skip in subsequent rounds). */
+    skippedDriverIds?: string[];
+}
+
+/**
+ * Find nearby available drivers using Redis GEOSEARCH.
+ * Returns driver member names (userId) sorted by distance ascending.
+ */
+export const findNearbyDrivers = async (
+    lng: number,
+    lat: number,
+    radiusKm: number,
+): Promise<string[]> => {
+    // GEOSEARCH returns members within radius, sorted by distance
+    const results = await redis.geosearch(
+        DRIVERS_GEO_KEY,
+        'FROMLONLAT',
+        lng,
+        lat,
+        'BYRADIUS',
+        radiusKm,
+        'km',
+        'ASC',
+    );
+
+    return results as string[];
+};
+
+/**
+ * Filter out drivers that are currently busy (on an active ride).
+ */
+export const filterBusyDrivers = async (driverUserIds: string[]): Promise<string[]> => {
+    if (driverUserIds.length === 0) return [];
+
+    const pipeline = redis.pipeline();
+    for (const id of driverUserIds) {
+        pipeline.sismember(DRIVERS_BUSY_KEY, id);
+    }
+    const results = await pipeline.exec();
+
+    return driverUserIds.filter((_, i) => {
+        const [err, isBusy] = results![i];
+        return !err && isBusy === 0;
+    });
+};
+
+/**
+ * Look up driver record by userId and return driverId.
+ * Returns null if driver doesn't exist.
+ */
+const getDriverId = async (userId: string): Promise<string | null> => {
+    const driver = await prisma.driver.findUnique({
+        where: { userId },
+        select: { id: true },
+    });
+    return driver?.id ?? null;
+};
+
+/**
+ * Run cascade matching for a ride.
+ * Finds the nearest available driver and sends them an offer.
+ * If no drivers are available, expands radius once, then cancels.
+ */
+export const runCascadeMatching = async (ctx: CascadeContext): Promise<void> => {
+    const { tripId, riderId, pickupLng, pickupLat, attempt } = ctx;
+    const skippedDriverIds = ctx.skippedDriverIds ?? [];
+
+    logger.info({ tripId, attempt, skippedCount: skippedDriverIds.length }, 'Running cascade matching');
+
+    if (attempt > MAX_CASCADE_ATTEMPTS) {
+        logger.warn({ tripId }, 'Max cascade attempts reached — cancelling ride');
+        await cancelRideNoDrivers(tripId, riderId);
+        return;
+    }
+
+    // Determine radius: expand after exhausting initial radius
+    const radius = attempt === 1 ? MATCHING_RADIUS_KM : MATCHING_EXPANDED_RADIUS_KM;
+
+    // 1. Find nearby drivers
+    const nearbyDriverUserIds = await findNearbyDrivers(pickupLng, pickupLat, radius);
+    logger.info({ tripId, nearbyCount: nearbyDriverUserIds.length, radius }, 'Nearby drivers found');
+
+    // 2. Filter out busy drivers and already-offered drivers
+    const availableDriverUserIds = (await filterBusyDrivers(nearbyDriverUserIds))
+        .filter((id) => !skippedDriverIds.includes(id));
+
+    if (availableDriverUserIds.length === 0) {
+        // If we haven't tried expanded radius yet, try once
+        if (radius === MATCHING_RADIUS_KM) {
+            logger.info({ tripId }, 'No drivers in initial radius — expanding to fallback radius');
+            await rideMatchingQueue.add(
+                'cascade-expanded',
+                {
+                    ...ctx,
+                    attempt: attempt + 1,
+                    skippedDriverIds,
+                },
+                { jobId: `match:${tripId}:${attempt + 1}` },
+            );
+            return;
+        }
+
+        logger.warn({ tripId }, 'No available drivers even with expanded radius — cancelling');
+        await cancelRideNoDrivers(tripId, riderId);
+        return;
+    }
+
+    // 3. Pick the nearest available driver (first in sorted list)
+    const targetDriverUserId = availableDriverUserIds[0];
+    const driverId = await getDriverId(targetDriverUserId);
+
+    if (!driverId) {
+        logger.warn({ tripId, targetDriverUserId }, 'Driver record not found — skipping');
+        await rideMatchingQueue.add(
+            'cascade-skip',
+            {
+                ...ctx,
+                attempt: attempt + 1,
+                skippedDriverIds: [...skippedDriverIds, targetDriverUserId],
+            },
+            { jobId: `match:${tripId}:${attempt + 1}` },
+        );
+        return;
+    }
+
+    // 4. Create RideOffer in DB
+    const expiresAt = new Date(Date.now() + OFFER_TIMEOUT_SECONDS * 1000);
+    const offer = await prisma.rideOffer.create({
+        data: {
+            tripId,
+            driverId,
+            expiresAt,
+        },
+    });
+
+    logger.info(
+        { tripId, offerId: offer.id, driverId, targetDriverUserId, expiresAt },
+        'Ride offer created — notifying driver',
+    );
+
+    // 5. Notify driver via Socket.io (ride:offer event to driver:{userId} room)
+    //    The notification happens via a lifecycle-style BullMQ job that the api-gateway
+    //    or a notification worker picks up. For now we emit a special matching job
+    //    that the api-gateway sockets can poll. In practice the ride-worker will use
+    //    the Redis pub/sub adapter to emit directly — this is wired up below.
+    await emitDriverOffer(targetDriverUserId, {
+        tripId,
+        offerId: offer.id,
+        pickupLng: ctx.pickupLng,
+        pickupLat: ctx.pickupLat,
+        dropoffLng: ctx.dropoffLng,
+        dropoffLat: ctx.dropoffLat,
+    });
+
+    // 6. Schedule timeout check (delayed job)
+    await rideMatchingQueue.add(
+        'offer-timeout',
+        {
+            tripId,
+            riderId: ctx.riderId,
+            offerId: offer.id,
+            pickupLng: ctx.pickupLng,
+            pickupLat: ctx.pickupLat,
+            dropoffLng: ctx.dropoffLng,
+            dropoffLat: ctx.dropoffLat,
+            attempt: attempt + 1,
+            skippedDriverIds: [...skippedDriverIds, targetDriverUserId],
+        },
+        {
+            delay: OFFER_TIMEOUT_SECONDS * 1000,
+            jobId: `timeout:${tripId}:${offer.id}`,
+        },
+    );
+};
+
+/**
+ * Handle offer timeout: check if still PENDING, mark EXPIRED, cascade.
+ */
+export const handleOfferTimeout = async (
+    offerId: string,
+    ctx: CascadeContext,
+): Promise<void> => {
+    const offer = await prisma.rideOffer.findUnique({ where: { id: offerId } });
+
+    if (!offer || offer.status !== 'PENDING') {
+        logger.info({ offerId, status: offer?.status }, 'Offer no longer pending — skipping timeout');
+        return;
+    }
+
+    // Mark as EXPIRED
+    await prisma.rideOffer.update({
+        where: { id: offerId },
+        data: { status: 'EXPIRED' },
+    });
+
+    // Notify driver that offer expired
+    const driver = await prisma.driver.findUnique({
+        where: { id: offer.driverId },
+        select: { userId: true },
+    });
+
+    if (driver) {
+        await emitDriverOfferExpired(driver.userId, {
+            tripId: ctx.tripId,
+            offerId,
+        });
+    }
+
+    logger.info({ offerId, tripId: ctx.tripId }, 'Offer expired — cascading to next driver');
+
+    // Continue cascade
+    await runCascadeMatching(ctx);
+};
+
+/**
+ * Emit ride:offer event to a driver via Redis pub/sub.
+ * The api-gateway's Socket.io Redis adapter picks this up and delivers.
+ */
+const emitDriverOffer = async (
+    driverUserId: string,
+    payload: Record<string, unknown>,
+): Promise<void> => {
+    await redis.publish(
+        'socket.io#/#',
+        JSON.stringify({
+            type: 2,
+            data: ['ride:offer', payload],
+            nsp: '/',
+            rooms: [`driver:${driverUserId}`],
+        }),
+    );
+};
+
+/**
+ * Emit ride:offer-expired event to a driver via Redis pub/sub.
+ */
+const emitDriverOfferExpired = async (
+    driverUserId: string,
+    payload: Record<string, unknown>,
+): Promise<void> => {
+    await redis.publish(
+        'socket.io#/#',
+        JSON.stringify({
+            type: 2,
+            data: ['ride:offer-expired', payload],
+            nsp: '/',
+            rooms: [`driver:${driverUserId}`],
+        }),
+    );
+};
+
+/**
+ * Cancel ride when no drivers are available.
+ */
+const cancelRideNoDrivers = async (tripId: string, riderId: string): Promise<void> => {
+    await rideLifecycleQueue.add(
+        'lifecycle-cancel',
+        {
+            action: 'CANCEL' as const,
+            tripId,
+            riderId,
+            reason: 'no drivers available',
+        },
+        { jobId: `cancel:${tripId}` },
+    );
+};
+
+export { rideLifecycleQueue, rideMatchingQueue };

--- a/apps/ride-worker/src/matching/index.ts
+++ b/apps/ride-worker/src/matching/index.ts
@@ -1,0 +1,7 @@
+export {
+    runCascadeMatching,
+    handleOfferTimeout,
+    findNearbyDrivers,
+    filterBusyDrivers,
+    type CascadeContext,
+} from './cascade.js';

--- a/apps/ride-worker/src/state-machine.ts
+++ b/apps/ride-worker/src/state-machine.ts
@@ -1,0 +1,43 @@
+import logger from './logger.js';
+
+type RideStatus = 'REQUESTED' | 'ACCEPTED' | 'STARTED' | 'COMPLETED' | 'CANCELLED';
+
+/**
+ * Valid ride status transitions.
+ *
+ *   REQUESTED → ACCEPTED  (driver accepts offer)
+ *   REQUESTED → CANCELLED (rider cancels, or no drivers found)
+ *   ACCEPTED  → STARTED   (OTP verified at pickup)
+ *   ACCEPTED  → CANCELLED (rider or driver cancels)
+ *   STARTED   → COMPLETED (driver ends ride — M5)
+ */
+const VALID_TRANSITIONS: Record<RideStatus, RideStatus[]> = {
+    REQUESTED: ['ACCEPTED', 'CANCELLED'],
+    ACCEPTED: ['STARTED', 'CANCELLED'],
+    STARTED: ['COMPLETED'],
+    COMPLETED: [],
+    CANCELLED: [],
+};
+
+/**
+ * Validate whether a status transition is allowed.
+ * Throws if the transition is invalid.
+ */
+export const validateTransition = (from: RideStatus, to: RideStatus): void => {
+    const allowed = VALID_TRANSITIONS[from];
+    if (!allowed || !allowed.includes(to)) {
+        const msg = `Invalid ride transition: ${from} → ${to}`;
+        logger.warn({ from, to }, msg);
+        throw new Error(msg);
+    }
+};
+
+/**
+ * Check if a transition is valid without throwing.
+ */
+export const isValidTransition = (from: RideStatus, to: RideStatus): boolean => {
+    const allowed = VALID_TRANSITIONS[from];
+    return !!allowed && allowed.includes(to);
+};
+
+export type { RideStatus };

--- a/apps/ride-worker/src/workers/ride-lifecycle.worker.ts
+++ b/apps/ride-worker/src/workers/ride-lifecycle.worker.ts
@@ -1,6 +1,19 @@
-import { Worker, Job } from 'bullmq';
+import { Worker, Job, Queue } from 'bullmq';
+import { PrismaClient } from '@prisma/client';
+import redis from '../utils/redis.js';
 import logger from '../logger.js';
 import { QUEUE_NAMES, REDIS_CONFIG } from '../config.js';
+import { validateTransition } from '../state-machine.js';
+import {
+  DRIVERS_BUSY_KEY,
+  OTP_KEY_PREFIX,
+  OTP_ATTEMPTS_KEY_PREFIX,
+  OTP_TTL_SECONDS,
+  MAX_OTP_ATTEMPTS,
+  RIDE_LOCK_KEY_PREFIX,
+} from 'common';
+
+const prisma = new PrismaClient();
 
 export type RideLifecycleAction = 'ACCEPT' | 'VERIFY_OTP' | 'START' | 'COMPLETE' | 'CANCEL';
 
@@ -9,33 +22,269 @@ export interface RideLifecycleJobData {
   tripId: string;
   driverId?: string;
   riderId?: string;
+  offerId?: string;
   otp?: string;
+  reason?: string;
 }
 
-// Skeleton processor — fully implemented in M4/M5
+/**
+ * Generate a 4-digit numeric OTP.
+ */
+const generateOtp = (): string =>
+  Math.floor(1000 + Math.random() * 9000).toString();
+
+/**
+ * Emit a Socket.io event via Redis pub/sub (cross-process).
+ */
+const emitToRoom = async (
+  room: string,
+  event: string,
+  payload: Record<string, unknown>,
+): Promise<void> => {
+  await redis.publish(
+    'socket.io#/#',
+    JSON.stringify({
+      type: 2,
+      data: [event, payload],
+      nsp: '/',
+      rooms: [room],
+    }),
+  );
+};
+
+// ─── ACCEPT ───────────────────────────────────────────────────────────────
+
+const handleAccept = async (data: RideLifecycleJobData): Promise<void> => {
+  const { tripId, driverId, offerId } = data;
+  if (!driverId || !offerId) throw new Error('ACCEPT requires driverId and offerId');
+
+  // 1. Get current trip status & validate transition
+  const trip = await prisma.trip.findUnique({ where: { id: tripId } });
+  if (!trip) throw new Error(`Trip ${tripId} not found`);
+  validateTransition(trip.status, 'ACCEPTED');
+
+  // 2. Mark offer as ACCEPTED
+  await prisma.rideOffer.update({
+    where: { id: offerId },
+    data: { status: 'ACCEPTED' },
+  });
+
+  // 3. Mark all other PENDING offers for this trip as EXPIRED
+  await prisma.rideOffer.updateMany({
+    where: { tripId, id: { not: offerId }, status: 'PENDING' },
+    data: { status: 'EXPIRED' },
+  });
+
+  // 4. Cancel any pending timeout jobs for this trip
+  const matchingQueue = new Queue(QUEUE_NAMES.RIDE_MATCHING, { connection: REDIS_CONFIG });
+  try {
+    // Remove delayed timeout jobs by pattern
+    const delayed = await matchingQueue.getDelayed();
+    for (const job of delayed) {
+      if (job.data.tripId === tripId && job.name === 'offer-timeout') {
+        await job.remove();
+      }
+    }
+  } finally {
+    await matchingQueue.close();
+  }
+
+  // 5. Update Trip: set driverId, status → ACCEPTED
+  await prisma.trip.update({
+    where: { id: tripId },
+    data: { driverId, status: 'ACCEPTED' },
+  });
+
+  // 6. Add driver to busy set
+  const driver = await prisma.driver.findUnique({ where: { id: driverId }, select: { userId: true } });
+  if (driver) {
+    await redis.sadd(DRIVERS_BUSY_KEY, driver.userId);
+  }
+
+  // 7. Generate OTP
+  const otp = generateOtp();
+
+  // 8. Store OTP in Redis with TTL
+  await redis.set(`${OTP_KEY_PREFIX}${tripId}`, otp, 'EX', OTP_TTL_SECONDS);
+
+  // 9. Save OTP to Trip record (audit trail)
+  await prisma.trip.update({
+    where: { id: tripId },
+    data: { otp },
+  });
+
+  // 10. Get rider userId for notification
+  const rider = await prisma.rider.findUnique({ where: { id: trip.riderId }, select: { userId: true } });
+
+  // 11. Notify rider via ride:accepted (includes driver info but NOT OTP)
+  if (rider) {
+    await emitToRoom(`rider:${rider.userId}`, 'ride:accepted', {
+      tripId,
+      driverId,
+    });
+
+    // 12. Notify rider via ride:otp separately
+    await emitToRoom(`rider:${rider.userId}`, 'ride:otp', {
+      tripId,
+      otp,
+    });
+  }
+
+  logger.info({ tripId, driverId, offerId, otp }, 'Ride ACCEPTED — OTP generated and sent');
+};
+
+// ─── VERIFY_OTP ───────────────────────────────────────────────────────────
+
+const handleVerifyOtp = async (data: RideLifecycleJobData): Promise<void> => {
+  const { tripId, otp, driverId } = data;
+  if (!otp) throw new Error('VERIFY_OTP requires otp');
+
+  // 1. Get stored OTP from Redis
+  const storedOtp = await redis.get(`${OTP_KEY_PREFIX}${tripId}`);
+  if (!storedOtp) throw new Error(`OTP for trip ${tripId} not found or expired`);
+
+  // 2. Track attempts
+  const attemptsKey = `${OTP_ATTEMPTS_KEY_PREFIX}${tripId}`;
+  const attempts = await redis.incr(attemptsKey);
+  await redis.expire(attemptsKey, OTP_TTL_SECONDS);
+
+  // 3. On match: transition to STARTED
+  if (otp === storedOtp) {
+    // Validate state transition
+    const trip = await prisma.trip.findUnique({ where: { id: tripId } });
+    if (!trip) throw new Error(`Trip ${tripId} not found`);
+    validateTransition(trip.status, 'STARTED');
+
+    // Update Trip status → STARTED
+    await prisma.trip.update({
+      where: { id: tripId },
+      data: { status: 'STARTED' },
+    });
+
+    // Delete OTP from Redis
+    await redis.del(`${OTP_KEY_PREFIX}${tripId}`);
+    await redis.del(attemptsKey);
+
+    // Notify ride room
+    await emitToRoom(`ride:${tripId}`, 'ride:started', { tripId });
+
+    logger.info({ tripId }, 'OTP verified — ride STARTED');
+    return;
+  }
+
+  // 4. On mismatch
+  const remaining = MAX_OTP_ATTEMPTS - attempts;
+
+  if (remaining <= 0) {
+    // Max attempts exceeded: cancel ride
+    logger.warn({ tripId, attempts }, 'Max OTP attempts exceeded — cancelling ride');
+    await handleCancel({
+      action: 'CANCEL',
+      tripId,
+      driverId,
+      reason: 'max OTP attempts exceeded',
+    });
+    return;
+  }
+
+  // Notify driver of wrong OTP via their personal room
+  if (driverId) {
+    const driver = await prisma.driver.findUnique({ where: { id: driverId }, select: { userId: true } });
+    if (driver) {
+      await emitToRoom(`driver:${driver.userId}`, 'ride:otp-error', {
+        tripId,
+        message: `Incorrect OTP. ${remaining} attempt(s) remaining.`,
+        remainingAttempts: remaining,
+      });
+    }
+  }
+
+  logger.info({ tripId, attempts, remaining }, 'OTP mismatch');
+};
+
+// ─── CANCEL ───────────────────────────────────────────────────────────────
+
+const handleCancel = async (data: RideLifecycleJobData): Promise<void> => {
+  const { tripId, reason } = data;
+
+  const trip = await prisma.trip.findUnique({ where: { id: tripId } });
+  if (!trip) throw new Error(`Trip ${tripId} not found`);
+
+  // Validate transition
+  validateTransition(trip.status, 'CANCELLED');
+
+  // Update Trip status → CANCELLED
+  await prisma.trip.update({
+    where: { id: tripId },
+    data: { status: 'CANCELLED' },
+  });
+
+  // If was ACCEPTED (has a driver assigned): remove from busy set
+  if (trip.driverId) {
+    const driver = await prisma.driver.findUnique({
+      where: { id: trip.driverId },
+      select: { userId: true },
+    });
+    if (driver) {
+      await redis.srem(DRIVERS_BUSY_KEY, driver.userId);
+    }
+  }
+
+  // Clean up Redis keys
+  await redis.del(`${OTP_KEY_PREFIX}${tripId}`);
+  await redis.del(`${OTP_ATTEMPTS_KEY_PREFIX}${tripId}`);
+  await redis.del(`${RIDE_LOCK_KEY_PREFIX}${tripId}`);
+
+  // Mark any PENDING offers as EXPIRED
+  await prisma.rideOffer.updateMany({
+    where: { tripId, status: 'PENDING' },
+    data: { status: 'EXPIRED' },
+  });
+
+  // Notify ride room
+  await emitToRoom(`ride:${tripId}`, 'ride:cancelled', {
+    tripId,
+    reason: reason ?? 'cancelled',
+  });
+
+  // Also notify rider personal room
+  const rider = await prisma.rider.findUnique({
+    where: { id: trip.riderId },
+    select: { userId: true },
+  });
+  if (rider) {
+    await emitToRoom(`rider:${rider.userId}`, 'ride:cancelled', {
+      tripId,
+      reason: reason ?? 'cancelled',
+    });
+  }
+
+  logger.info({ tripId, reason }, 'Ride CANCELLED');
+};
+
+// ─── MAIN PROCESSOR ──────────────────────────────────────────────────────
+
 const processRideLifecycle = async (job: Job<RideLifecycleJobData>) => {
   const { action, tripId } = job.data;
 
-  logger.info(
-    { action, tripId },
-    'ride-lifecycle job received — state transitions will be implemented in M4/M5',
-  );
+  logger.info({ action, tripId, jobId: job.id }, 'ride-lifecycle job received');
 
   switch (action) {
     case 'ACCEPT':
-      logger.info({ tripId }, 'ACCEPT action — driver matching accept (M4)');
+      await handleAccept(job.data);
       break;
     case 'VERIFY_OTP':
-      logger.info({ tripId }, 'VERIFY_OTP action — OTP verification (M4)');
+      await handleVerifyOtp(job.data);
       break;
     case 'START':
-      logger.info({ tripId }, 'START action — ride start (M4)');
+      // START is handled inline after VERIFY_OTP succeeds
+      logger.info({ tripId }, 'START action — handled via VERIFY_OTP flow');
       break;
     case 'COMPLETE':
-      logger.info({ tripId }, 'COMPLETE action — ride completion and fare calculation (M5)');
+      logger.info({ tripId }, 'COMPLETE action — will be implemented in M5');
       break;
     case 'CANCEL':
-      logger.info({ tripId }, 'CANCEL action — ride cancellation (M4)');
+      await handleCancel(job.data);
       break;
     default:
       logger.warn({ action, tripId }, 'Unknown ride lifecycle action');

--- a/apps/ride-worker/src/workers/ride-matching.worker.ts
+++ b/apps/ride-worker/src/workers/ride-matching.worker.ts
@@ -1,32 +1,57 @@
 import { Worker, Job } from 'bullmq';
 import logger from '../logger.js';
 import { QUEUE_NAMES, REDIS_CONFIG } from '../config.js';
+import { runCascadeMatching, handleOfferTimeout, type CascadeContext } from '../matching/index.js';
 
-export interface RideMatchingJobData {
-  tripId: string;
-  riderId: string;
-  pickupLng: number;
-  pickupLat: number;
-  dropoffLng: number;
-  dropoffLat: number;
-  attempt?: number;
+export interface RideMatchingJobData extends CascadeContext {
+  offerId?: string;
 }
 
-// Skeleton processor — fully implemented in M4 (nearest-first cascade)
+/**
+ * Process ride-matching jobs:
+ * - 'match-driver': Initial cascade from ride-request worker
+ * - 'cascade-expanded' / 'cascade-skip': Continued cascade
+ * - 'offer-timeout': Delayed job checking if an offer expired
+ */
 const processRideMatching = async (job: Job<RideMatchingJobData>) => {
-  const { tripId, riderId, attempt = 1 } = job.data;
+  const { tripId, attempt = 1 } = job.data;
 
   logger.info(
-    { tripId, riderId, attempt },
-    'ride-matching job received — matching algorithm will be implemented in M4',
+    { tripId, jobName: job.name, attempt, jobId: job.id },
+    'ride-matching job received',
   );
+
+  if (job.name === 'offer-timeout' && job.data.offerId) {
+    // Handle timeout for a specific offer
+    await handleOfferTimeout(job.data.offerId, {
+      tripId: job.data.tripId,
+      riderId: job.data.riderId,
+      pickupLng: job.data.pickupLng,
+      pickupLat: job.data.pickupLat,
+      dropoffLng: job.data.dropoffLng,
+      dropoffLat: job.data.dropoffLat,
+      attempt: job.data.attempt ?? attempt,
+      skippedDriverIds: job.data.skippedDriverIds,
+    });
+  } else {
+    // Run cascade matching (initial or continued)
+    await runCascadeMatching({
+      tripId: job.data.tripId,
+      riderId: job.data.riderId,
+      pickupLng: job.data.pickupLng,
+      pickupLat: job.data.pickupLat,
+      dropoffLng: job.data.dropoffLng,
+      dropoffLat: job.data.dropoffLat,
+      attempt: job.data.attempt ?? attempt,
+      skippedDriverIds: job.data.skippedDriverIds,
+    });
+  }
 };
 
 export const createRideMatchingWorker = () => {
   const worker = new Worker<RideMatchingJobData>(QUEUE_NAMES.RIDE_MATCHING, processRideMatching, {
     connection: REDIS_CONFIG,
     concurrency: 10,
-    // Support for delayed jobs needed for matching timeout cascade (M4)
   });
 
   worker.on('completed', (job) => {

--- a/apps/ride-worker/vitest.config.ts
+++ b/apps/ride-worker/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: 'node',
+        include: ['src/**/*.test.ts'],
+        exclude: ['dist/**', 'node_modules/**'],
+        clearMocks: true,
+        restoreMocks: true,
+    },
+});

--- a/learn/m3-socketio-notifications.md
+++ b/learn/m3-socketio-notifications.md
@@ -1,0 +1,222 @@
+# M3 — Socket.io Real-Time Layer & Notification Service
+
+> **Branch:** `feature/m3-socketio-realtime` | **Closes:** Issue #8
+
+---
+
+## What is this milestone about?
+
+M3 adds **real-time WebSocket communication** between clients (riders, drivers) and the server. It also creates a clean **notification abstraction layer** that lets any part of the system (api-gateway, ride-worker) emit events to clients without knowing the transport layer.
+
+---
+
+## Why WebSockets instead of REST polling?
+
+REST is request-driven — the client must ask "did anything change?" repeatedly. WebSockets flip this: the server pushes events to clients the moment they happen. For a ride-sharing app, this is critical:
+
+- Driver location updates happen every few seconds → polling would crush the server
+- Ride status changes (accepted, started, completed) must feel instant to users
+- Match offers must be delivered to drivers in real-time or they expire
+
+---
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────┐
+│              api-gateway (Express)            │
+│                                               │
+│  HTTP Server (http.createServer)              │
+│      ├── Express REST routes  (same port!)    │
+│      └── Socket.io server    (same port!)     │
+│             ├── JWT auth middleware           │
+│             ├── driver handlers               │
+│             └── rider handlers                │
+└──────────────────────────────────────────────┘
+          │                    │
+     Redis pub/sub         Redis GEO
+          │
+┌─────────────────────┐
+│    ride-worker      │  ← publishes events via Redis adapter (M4+)
+└─────────────────────┘
+```
+
+**Key insight:** Socket.io and Express share the **same HTTP server and port**. The Socket.io handshake is an HTTP Upgrade request — once upgraded to a WebSocket, it stays on a persistent connection.
+
+---
+
+## What changed in `index.ts`?
+
+Before M3:
+```ts
+app.listen(PORT, () => { ... });   // Express owns the server
+```
+
+After M3:
+```ts
+const server = http.createServer(app);  // http owns the server
+initSocketServer(server);               // Socket.io attaches to it
+server.listen(PORT, () => { ... });     // same port, both protocols
+```
+
+---
+
+## Files Created
+
+| File | Purpose |
+|------|---------|
+| `packages/common/events/index.ts` | `SOCKET_EVENTS` constants shared across api-gateway and ride-worker |
+| `packages/notifications/src/types/index.ts` | `NotificationChannel` interface definition |
+| `packages/notifications/src/channels/socket.channel.ts` | `SocketChannel` — emits via Socket.io, supports Redis adapter |
+| `packages/notifications/src/service.ts` | `NotificationService` class with `notifyDriver/Rider/Ride()` helpers |
+| `packages/notifications/src/index.ts` | Main exports |
+| `apps/api-gateway/src/sockets/index.ts` | Socket.io server init, Redis adapter, role-based handler routing |
+| `apps/api-gateway/src/sockets/auth.ts` | JWT socket middleware |
+| `apps/api-gateway/src/sockets/handlers/driver.ts` | Driver socket events |
+| `apps/api-gateway/src/sockets/handlers/rider.ts` | Rider socket events |
+
+---
+
+## Socket Rooms Strategy
+
+Socket.io has **rooms** — named channels you can broadcast to. Our strategy uses 3 types:
+
+| Room | Members | Used for |
+|------|---------|---------|
+| `driver:{driverId}` | Only that driver | Ride offers, personal notifications |
+| `rider:{riderId}` | Only that rider | Ride status updates, OTP |
+| `ride:{tripId}` | Both assigned driver + rider | Location stream, shared status |
+
+Every connection auto-joins its personal room. Riders join `ride:{tripId}` by emitting `rider:subscribe-driver-location`.
+
+---
+
+## Authentication Flow
+
+Every WebSocket connection goes through a JWT check **before** connection is accepted:
+
+```
+Client → socket.connect({ auth: { token: "eyJ..." } })
+         ↓
+socketAuthMiddleware runs:
+  1. Extract token from auth.token or Authorization header
+  2. Call verifyToken() (same function REST uses)
+  3. Attach decoded payload to socket.data.user
+  4. Call next() → connection accepted
+   OR
+  4. Call next(Error) → connection rejected (client gets error event)
+```
+
+---
+
+## Driver Events
+
+| Client emits | Payload | Server does |
+|---|---|---|
+| `driver:go-online` | `{ lng, lat }` | DB update + Redis GEO add + heartbeat |
+| `driver:go-offline` | — | DB update + Redis GEO remove |
+| `driver:location-update` | `{ lng, lat }` | Redis GEO update (fast, no DB) |
+
+> **Why no DB for location-update?** Location can change every few seconds. Writing to PostgreSQL every second would be overwhelming. Redis GEO handles this in-memory at microsecond latency. The DB only needs to know `isActive: true/false`.
+
+---
+
+## Rider Events
+
+| Client emits | Payload | Server does |
+|---|---|---|
+| `rider:subscribe-driver-location` | `{ tripId }` | Validates trip ownership, joins `ride:{tripId}` room |
+| `rider:unsubscribe-driver-location` | `{ tripId }` | Leaves `ride:{tripId}` room |
+
+**Ownership validation** is important: without it, any rider could subscribe to any trip's location stream (privacy violation).
+
+---
+
+## Notification Service — Why an Abstraction?
+
+The `packages/notifications` package is a **channel pattern**:
+
+```
+NotificationService
+  ├── SocketChannel   ← currently only this
+  ├── SmsChannel      ← add later (Twilio)
+  └── PushChannel     ← add later (FCM)
+```
+
+When you call `notifyDriver(driverId, SOCKET_EVENTS.RIDE_OFFER, data)`, it fans out to **all registered channels**. Adding SMS in the future means:
+1. Create `SmsChannel implements NotificationChannel`
+2. Pass it to `createNotificationService([socketChannel, smsChannel])`
+3. No changes to calling code
+
+---
+
+## Redis Adapter — How Cross-Process Emission Works
+
+```
+ride-worker (no Socket.io)
+    │
+    │  publish to Redis pub/sub channel
+    ↓
+Redis
+    │
+    │  adapter subscribes and receives message
+    ↓
+api-gateway Socket.io server
+    │
+    │  io.to('driver:abc').emit('ride:offer', data)
+    ↓
+Client WebSocket
+```
+
+The ride-worker never has direct access to the WebSocket connections (those live in api-gateway). But by using the Redis adapter's pub/sub mechanism, any process can trigger emissions to any connected client.
+
+---
+
+## SOCKET_EVENTS Constants
+
+```ts
+SOCKET_EVENTS.RIDE_OFFER          // 'ride:offer'
+SOCKET_EVENTS.RIDE_OFFER_EXPIRED  // 'ride:offer-expired'
+SOCKET_EVENTS.RIDE_ACCEPTED       // 'ride:accepted'
+SOCKET_EVENTS.RIDE_STARTED        // 'ride:started'
+SOCKET_EVENTS.RIDE_COMPLETED      // 'ride:completed'
+SOCKET_EVENTS.RIDE_CANCELLED      // 'ride:cancelled'
+SOCKET_EVENTS.DRIVER_LOCATION     // 'ride:driver-location'
+SOCKET_EVENTS.OTP_GENERATED       // 'ride:otp'
+```
+
+Using string constants prevents typos and gives intellisense. When M4 starts sending `RIDE_OFFER` events to drivers, it imports from `common/events` — no magic strings anywhere.
+
+---
+
+## How to Test Manually (when Docker is running)
+
+```ts
+// Client-side (pseudocode)
+import { io } from 'socket.io-client';
+
+const socket = io('ws://localhost:3001', {
+  transports: ['websocket'],
+  auth: { token: '<JWT from POST /auth/login>' }
+});
+
+// Driver client
+socket.emit('driver:go-online', { lng: 77.5946, lat: 12.9716 });
+
+// Rider client — subscribe to live location during ride
+socket.emit('rider:subscribe-driver-location', { tripId: '<uuid>' });
+socket.on('ride:driver-location', (data) => {
+  console.log('Driver at:', data);
+});
+```
+
+---
+
+## What comes next (M4)?
+
+When a driver is matched to a ride, M4's ride-worker will:
+```ts
+const notifier = createNotificationService([new SocketChannel(io)]);
+await notifier.notifyDriver(driverId, SOCKET_EVENTS.RIDE_OFFER, { tripId, ... });
+```
+The notification service + Redis adapter ensures this works even though the worker has no direct socket connections.

--- a/learn/m4-matching-lifecycle.md
+++ b/learn/m4-matching-lifecycle.md
@@ -1,0 +1,149 @@
+# M4 — Driver Matching & Ride Lifecycle
+
+> **Branch:** `feature/m4-matching-lifecycle` | **Closes:** Issue #9
+
+---
+
+## What this milestone does
+
+M4 turns the skeleton workers from M2 into a working ride-sharing pipeline. When a rider requests a ride, the system now:
+
+1. Searches for the nearest available driver using Redis GEO
+2. Sends them a ride offer with a 30-second timeout
+3. If they don't respond, cascades to the next closest driver
+4. When accepted, generates a 4-digit OTP for pickup verification
+5. When the OTP is verified, the ride starts
+
+---
+
+## Cascade Matching — How it works
+
+```
+Rider requests ride
+    │
+    ▼
+ride-request worker → publishes to ride-matching queue
+    │
+    ▼
+ride-matching worker
+    │
+    ├── GEOSEARCH Redis GEO (5km radius, sorted by distance)
+    ├── Filter out drivers:busy set (currently on a ride)
+    ├── Filter out already-offered drivers
+    │
+    ├── FOUND: Send offer to nearest driver
+    │   ├── Create RideOffer record (PENDING, 30s expiry)
+    │   ├── Emit ride:offer to driver:{userId} room via Redis pub/sub
+    │   └── Schedule delayed timeout job (30s)
+    │
+    ├── TIMEOUT: Offer still PENDING after 30s?
+    │   ├── Mark EXPIRED
+    │   ├── Notify driver (ride:offer-expired)
+    │   └── Cascade to next driver
+    │
+    └── NO DRIVERS: Expand to 10km → still none? → CANCEL trip
+```
+
+### Why Redis GEO + Redis Set?
+
+- **Redis GEO** (`GEOSEARCH`) returns drivers sorted by distance in O(log(N)+M) — faster than any SQL query
+- **`drivers:busy` set** is an O(1) membership check — avoids N separate DB lookups to check if each driver is on a ride
+
+---
+
+## Ride State Machine
+
+```
+REQUESTED ──→ ACCEPTED ──→ STARTED ──→ COMPLETED (M5)
+    │             │
+    └──→ CANCELLED ←──┘
+```
+
+Invalid transitions (e.g., REQUESTED→STARTED) throw immediately. Terminal states (COMPLETED, CANCELLED) allow no further transitions.
+
+**File:** `apps/ride-worker/src/state-machine.ts`
+
+---
+
+## OTP System
+
+| Step | What happens |
+|------|-------------|
+| 1. Generate | 4-digit random: `Math.floor(1000 + Math.random() * 9000)` |
+| 2. Store | Redis `otp:{tripId}` with 15-minute TTL + DB `Trip.otp` for audit |
+| 3. Verify | Driver submits OTP at pickup via `POST /rides/:tripId/verify-otp` |
+| 4. Max attempts | 3 tries (tracked in Redis `otp:attempts:{tripId}`). Exceeded → auto-cancel |
+| 5. On match | Trip status → STARTED, OTP keys deleted from Redis |
+
+---
+
+## Race Condition Protection — SETNX Lock
+
+Two drivers could try accepting the same ride simultaneously. Solution:
+
+```
+Driver A: SETNX ride:lock:{tripId} → OK (wins)
+Driver B: SETNX ride:lock:{tripId} → null (already locked!)
+           └── "Ride has already been accepted by another driver"
+```
+
+The lock has a 300-second TTL as a safety net.
+
+---
+
+## Socket Events (new)
+
+| Event | Direction | Payload |
+|-------|-----------|---------|
+| `ride:offer` | server→driver | `{ tripId, offerId, pickupLng/Lat, dropoffLng/Lat }` |
+| `ride:offer-expired` | server→driver | `{ tripId, offerId }` |
+| `ride:accepted` | server→rider | `{ tripId, driverId }` |
+| `ride:otp` | server→rider | `{ tripId, otp }` |
+| `ride:started` | server→ride room | `{ tripId }` |
+| `ride:cancelled` | server→ride room + rider | `{ tripId, reason }` |
+| `ride:otp-error` | server→driver | `{ tripId, message, remainingAttempts }` |
+| `driver:accept-ride` | driver→server | `{ tripId, offerId }` |
+| `driver:reject-ride` | driver→server | `{ tripId, offerId }` |
+
+---
+
+## REST Endpoints (new)
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| POST | `/rides/:tripId/accept` | driver | Accept ride (SETNX lock) |
+| POST | `/rides/:tripId/reject` | driver | Reject → cascade |
+| POST | `/rides/:tripId/verify-otp` | driver | OTP verification |
+| POST | `/rides/:tripId/driver-cancel` | driver | Driver cancels accepted ride |
+| PATCH | `/rides/cancel` | rider | Enhanced with `{ tripId }` body |
+
+---
+
+## Schema Changes
+
+Added to **Trip**: `otp String?`, `fare Float?`, `distance Float?`
+
+New model **RideOffer**: `id`, `tripId`, `driverId`, `status (PENDING|ACCEPTED|REJECTED|EXPIRED)`, `createdAt`, `expiresAt`
+
+---
+
+## Cross-Process Socket Emission
+
+The ride-worker has no direct Socket.io connections — those live in api-gateway. It emits events via Redis pub/sub:
+
+```ts
+await redis.publish('socket.io#/#', JSON.stringify({
+  type: 2,
+  data: ['ride:offer', payload],
+  nsp: '/',
+  rooms: ['driver:userId123'],
+}));
+```
+
+The api-gateway's Redis adapter picks this up and delivers to the correct socket.
+
+---
+
+## What's next (M5)?
+
+M5 will implement ride completion with fare calculation — the `STARTED → COMPLETED` transition that the state machine already allows.

--- a/packages/common/constants/matching.ts
+++ b/packages/common/constants/matching.ts
@@ -1,0 +1,34 @@
+/** Cascade matching algorithm constants. */
+
+/** Initial search radius in km for finding nearby drivers. */
+export const MATCHING_RADIUS_KM = 5;
+
+/** Expanded radius in km (fallback after initial radius exhausted). */
+export const MATCHING_EXPANDED_RADIUS_KM = 10;
+
+/** Seconds to wait for a driver to accept before cascading to the next. */
+export const OFFER_TIMEOUT_SECONDS = 30;
+
+/** Maximum number of drivers to offer a ride to before cancelling. */
+export const MAX_CASCADE_ATTEMPTS = 10;
+
+/** Redis key for the set of busy (on-ride) driver IDs. */
+export const DRIVERS_BUSY_KEY = 'drivers:busy';
+
+/** Redis key for the GEO set of active driver positions. */
+export const DRIVERS_GEO_KEY = 'drivers:active';
+
+/** Redis key prefix for OTPs — full key: `otp:{tripId}` */
+export const OTP_KEY_PREFIX = 'otp:';
+
+/** Redis key prefix for OTP attempt counters — full key: `otp:attempts:{tripId}` */
+export const OTP_ATTEMPTS_KEY_PREFIX = 'otp:attempts:';
+
+/** Maximum OTP verification attempts before cancellation. */
+export const MAX_OTP_ATTEMPTS = 3;
+
+/** OTP TTL in seconds (15 minutes). */
+export const OTP_TTL_SECONDS = 15 * 60;
+
+/** Redis key prefix for distributed ride lock — full key: `ride:lock:{tripId}` */
+export const RIDE_LOCK_KEY_PREFIX = 'ride:lock:';

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -1,5 +1,6 @@
 export * from './schemas/index.js';
 export * from './queues/index.js';
 export * from './events/index.js';
+export * from './constants/matching.js';
 
 export { PrismaClient } from '@prisma/client';

--- a/packages/common/prisma/migrations/20260306_add_ride_offers_and_trip_fields/migration.sql
+++ b/packages/common/prisma/migrations/20260306_add_ride_offers_and_trip_fields/migration.sql
@@ -1,0 +1,29 @@
+-- CreateEnum
+CREATE TYPE "OfferStatus" AS ENUM ('PENDING', 'ACCEPTED', 'REJECTED', 'EXPIRED');
+
+-- AlterTable: add otp, fare, distance to Trip
+ALTER TABLE "Trip" ADD COLUMN "otp" TEXT,
+ADD COLUMN "fare" DOUBLE PRECISION,
+ADD COLUMN "distance" DOUBLE PRECISION;
+
+-- CreateTable: RideOffer
+CREATE TABLE "RideOffer" (
+    "id" TEXT NOT NULL,
+    "tripId" TEXT NOT NULL,
+    "driverId" TEXT NOT NULL,
+    "status" "OfferStatus" NOT NULL DEFAULT 'PENDING',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RideOffer_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "RideOffer" ADD CONSTRAINT "RideOffer_tripId_fkey" FOREIGN KEY ("tripId") REFERENCES "Trip"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RideOffer" ADD CONSTRAINT "RideOffer_driverId_fkey" FOREIGN KEY ("driverId") REFERENCES "Driver"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "RideOffer_tripId_idx" ON "RideOffer"("tripId");
+CREATE INDEX "RideOffer_driverId_idx" ON "RideOffer"("driverId");

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -18,6 +18,13 @@ enum RideStatus {
   CANCELLED
 }
 
+enum OfferStatus {
+  PENDING
+  ACCEPTED
+  REJECTED
+  EXPIRED
+}
+
 // generic user model that extends to both types
 model User {
   id        String   @id @default(uuid())
@@ -31,12 +38,13 @@ model User {
 }
 
 model Driver {
-  id       String                               @id @default(uuid())
-  userId   String                               @unique
-  user     User                                 @relation(fields: [userId], references: [id])
-  isActive Boolean                              @default(false)
-  location Unsupported("geometry(Point,4326)")?
-  trips    Trip[]
+  id         String                               @id @default(uuid())
+  userId     String                               @unique
+  user       User                                 @relation(fields: [userId], references: [id])
+  isActive   Boolean                              @default(false)
+  location   Unsupported("geometry(Point,4326)")?
+  trips      Trip[]
+  rideOffers RideOffer[]
 }
 
 model Rider {
@@ -55,6 +63,21 @@ model Trip {
   status          RideStatus                          @default(REQUESTED)
   pickupLocation  Unsupported("geometry(Point,4326)")
   dropoffLocation Unsupported("geometry(Point,4326)")
+  otp             String?
+  fare            Float?
+  distance        Float?
   createdAt       DateTime                            @default(now())
   completedAt     DateTime?
+  rideOffers      RideOffer[]
+}
+
+model RideOffer {
+  id        String      @id @default(uuid())
+  tripId    String
+  trip      Trip        @relation(fields: [tripId], references: [id])
+  driverId  String
+  driver    Driver      @relation(fields: [driverId], references: [id])
+  status    OfferStatus @default(PENDING)
+  createdAt DateTime    @default(now())
+  expiresAt DateTime
 }

--- a/packages/common/schemas/index.ts
+++ b/packages/common/schemas/index.ts
@@ -1,3 +1,4 @@
 export * from './user.schema.js';
 export * from './ride.schema.js';
 export * from './driver.schema.js';
+export * from './otp.schema.js';

--- a/packages/common/schemas/otp.schema.ts
+++ b/packages/common/schemas/otp.schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/** Schema for OTP verification request body. */
+export const otpVerifySchema = z.object({
+    body: z.object({
+        otp: z.string().length(4, 'OTP must be exactly 4 digits').regex(/^\d{4}$/, 'OTP must be numeric'),
+    }),
+});
+
+export type OtpVerifyInput = z.infer<typeof otpVerifySchema>['body'];
+
+/** Schema for enhanced ride cancellation with explicit tripId. */
+export const rideCancelSchema = z.object({
+    body: z.object({
+        tripId: z.string().uuid('tripId must be a valid UUID'),
+    }),
+});
+
+export type RideCancelInput = z.infer<typeof rideCancelSchema>['body'];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       '@types/node':
         specifier: ^24.5.2
         version: 24.8.1
+      '@vitest/coverage-v8':
+        specifier: ^4.0.18
+        version: 4.0.18(vitest@4.0.18(@types/node@24.8.1)(jiti@2.6.1)(tsx@4.20.6))
       pino-pretty:
         specifier: ^13.1.2
         version: 13.1.2
@@ -154,6 +157,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@24.8.1)(jiti@2.6.1)(tsx@4.20.6)
 
   packages/common:
     dependencies:
@@ -1898,9 +1904,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.1:
-    resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
-
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -3298,7 +3301,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   make-error@1.3.6: {}
 
@@ -3394,7 +3397,7 @@ snapshots:
       consola: 3.4.2
       pathe: 2.0.3
       pkg-types: 2.3.0
-      tinyexec: 1.0.1
+      tinyexec: 1.0.2
 
   object-assign@4.1.1: {}
 
@@ -3797,8 +3800,6 @@ snapshots:
       real-require: 0.2.0
 
   tinybench@2.9.0: {}
-
-  tinyexec@1.0.1: {}
 
   tinyexec@1.0.2: {}
 


### PR DESCRIPTION
## Overview

Implements Issue #9 — nearest-first cascade driver matching, ride state machine, OTP pickup verification, and full ride lifecycle processing.

## What Changed

### Schema Migration
- New `RideOffer` model + `OfferStatus` enum (`PENDING|ACCEPTED|REJECTED|EXPIRED`)
- Added `otp`, `fare`, `distance` to `Trip`
- Migration SQL at `packages/common/prisma/migrations/20260306_add_ride_offers_and_trip_fields/`

### packages/common
- `constants/matching.ts` — MATCHING_RADIUS_KM (5), EXPANDED (10), OFFER_TIMEOUT (30s), MAX_CASCADE (10), Redis key prefixes
- `schemas/otp.schema.ts` — Zod schemas for OTP verification + ride cancel with tripId

### ride-worker — Core Engine

**State Machine** (`state-machine.ts`)
```
REQUESTED → ACCEPTED → STARTED → COMPLETED (M5)
    │           │
    └→ CANCELLED ←┘
```

**Cascade Matching** (`matching/cascade.ts`)
1. `GEOSEARCH` Redis GEO for drivers within radius, sorted by distance
2. Filter `drivers:busy` Redis set
3. Send offer → create `RideOffer` → schedule 30s timeout
4. Timeout while PENDING → EXPIRED → cascade to next driver
5. All drivers exhausted → expand radius once → cancel if still empty

**ride-matching.worker.ts** — dispatches cascade/timeout jobs

**ride-lifecycle.worker.ts** — full implementations:
- **ACCEPT**: SETNX lock → offer ACCEPTED → set Trip.driverId → add to busy set → generate OTP → Redis TTL + DB audit → notify rider (`ride:accepted` + `ride:otp`)
- **VERIFY_OTP**: compare OTP, max 3 attempts (Redis counter), match → STARTED, exceeded → auto-cancel
- **CANCEL**: validate state → CANCELLED → cleanup Redis (OTP, lock, busy set, attempts) → expire pending offers → notify rooms

### api-gateway — API Layer

**Socket Events:**
- `driver:accept-ride { tripId, offerId }` — SETNX lock → lifecycle ACCEPT job
- `driver:reject-ride { tripId, offerId }` — mark REJECTED → immediate cascade

**REST Endpoints:**
| Method | Path | Auth | Purpose |
|--------|------|------|---------|
| POST | `/rides/:tripId/accept` | driver | REST fallback for accept |
| POST | `/rides/:tripId/reject` | driver | REST fallback for reject |
| POST | `/rides/:tripId/verify-otp` | driver | OTP verification |
| POST | `/rides/:tripId/driver-cancel` | driver | Driver cancels ride |
| PATCH | `/rides/cancel` | rider | Enhanced with `{ tripId }` body |

**Race Condition Protection:**
```
SETNX ride:lock:{tripId} → first driver wins, second gets "already accepted"
```

### Cross-Process Notification
ride-worker emits socket events via Redis pub/sub → api-gateway's Redis adapter delivers to clients

## Tests

**71 tests total** (all passing):

| Suite | Tests |
|-------|-------|
| api-gateway socket auth | 5 |
| api-gateway driver handler | 7 (+ accept/reject) |
| api-gateway rider handler | 5 |
| api-gateway auth service | 9 |
| api-gateway driver service | 10 |
| api-gateway ride service | 11 (+ accept/reject/OTP/lock) |
| api-gateway schemas | 11 |
| ride-worker state machine | 13 |

```
TypeScript: api-gateway OK | ride-worker OK | common OK
```

## Depends On
- M1 (Redis GEO), M2 (BullMQ infrastructure), M3 (Socket.io layer)

## Blocks
- M5 (STARTED → COMPLETED + fare calculation)

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drivers can now accept or reject ride offers with real-time acknowledgments and automatic room joining.
  * Added one-time password (OTP) verification for pickup confirmation with attempt tracking.
  * Riders can cancel rides by specifying trip ID; drivers can cancel accepted rides.
  * Implemented intelligent driver cascade matching using location-based search with automatic fallback radius expansion.
  * Enhanced real-time notifications for ride lifecycle status updates via socket events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->